### PR TITLE
Add continuous integration from travis-ci.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-/build
-/lib
-/include
+build/
+lib/
+include/
 
 boot.dol
 boot.elf
 ntsc102.c
 .vscode/
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ cache:
     - $HOME/Library/Caches/Homebrew
 
 env:
-  - DEVKITPRO=/opt/devkitpro
-  - DEVKITARM=${DEVKITPRO}/devkitARM
-  - DEVKITPPC=${DEVKITPRO}/devkitPPC
-  - PATH=${DEVKITPRO}/tools/bin:$PATH
+  - DEVKITPRO=/opt/devkitpro DEVKITARM=${DEVKITPRO}/devkitARM DEVKITPPC=${DEVKITPRO}/devkitPPC PATH=${DEVKITPRO}/tools/bin:$PATH
 
 before_install:
   - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,16 @@
 os: osx
 language: c
 
-cache:
-  directories:
-    - $HOME/Library/Caches/Homebrew
-
 env:
   - DEVKITPRO=/opt/devkitpro DEVKITARM=${DEVKITPRO}/devkitARM DEVKITPPC=${DEVKITPRO}/devkitPPC PATH=${DEVKITPRO}/tools/bin:$PATH
 
 before_install:
-  - brew update
   - curl -o devkitpro.pkg 'https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman-installer.pkg'
   - sudo installer -pkg devkitpro.pkg -target /
   - sudo dkp-pacman -S gamecube-dev wii-dev --noconfirm
 
 script:
   - make
-  
-before_cache:
-  - brew cleanup
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
   - DEVKITPRO=/opt/devkitpro DEVKITARM=${DEVKITPRO}/devkitARM DEVKITPPC=${DEVKITPRO}/devkitPPC PATH=${DEVKITPRO}/tools/bin:$PATH
 
 before_install:
-  - curl -o devkitpro.pkg 'https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman-installer.pkg'
-  - sudo installer -pkg devkitpro.pkg -target /
+  - curl -o devkitpro.pkg -LJO 'https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman-installer.pkg'
+  - sudo installer -allowUntrusted -verboseR -pkg "$(pwd)/devkitpro.pkg" -target /
   - sudo dkp-pacman -S gamecube-dev wii-dev --noconfirm
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+os: osx
+language: c
+
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew
+
+env:
+  - DEVKITPRO=/opt/devkitpro
+  - DEVKITARM=${DEVKITPRO}/devkitARM
+  - DEVKITPPC=${DEVKITPRO}/devkitPPC
+  - PATH=${DEVKITPRO}/tools/bin:$PATH
+
+before_install:
+  - brew update
+  - curl -o devkitpro.pkg 'https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman-installer.pkg'
+  - sudo installer -pkg devkitpro.pkg -target /
+  - sudo dkp-pacman -S gamecube-dev wii-dev --noconfirm
+
+script:
+  - make
+  
+before_cache:
+  - brew cleanup
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# What is FRAY?
+# What is FRAY? [![Build Status](https://www.travis-ci.org/PsiLupan/FRAY.svg?branch=master)](https://www.travis-ci.org/PsiLupan/FRAY)
 FRAY is a intended to be a recompilable version of the Super Smash Bros. Melee NTSC 1.02 DOL (or DOLphin executable). The term "fray" itself is a synonym to "melee," as I prefer not to infringe on "brawl" or the original game's name.
 
 Unlike other projects, FRAY does not currently intend to integrate a mix of ASM and C, unless it becomes necessary for certain functions like Dolphin SDK or HAL library components that are largely optimized for ASM.


### PR DESCRIPTION
Obviously the builds will fail right now since we can't yet fully compile the project. However it'll help us keep track of the current build process and PRs.

P.S. It'll also require @PsiLupan to enable the repository on https://travis-ci.org.